### PR TITLE
Update translate quickstart.js to contain apiKey param

### DIFF
--- a/translate/quickstart.js
+++ b/translate/quickstart.js
@@ -21,10 +21,12 @@ const Translate = require('@google-cloud/translate');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';
+const apiKey = 'YOUR_API_KEY';
 
 // Instantiates a client
 const translateClient = Translate({
-  projectId: projectId
+  projectId: projectId,
+  key: apiKey
 });
 
 // The text to translate


### PR DESCRIPTION
Add the key : apiKey field to the quickstart.js. Without it, the node module will call the endpoint for unregistered requests and eventually only return 403 user rate limit exceeded error.
This parameter is listed in the Readme.md of the @google-cloud/translate but not shown on the quickstart which can confuse users.